### PR TITLE
Make tpu codepath work w/ hydra.

### DIFF
--- a/fairseq/metsumm.py
+++ b/fairseq/metsumm.py
@@ -1,5 +1,6 @@
 # FIXME: remove this file
 def metsumm(stepno=''):
+    import torch_xla.core.xla_model as xm
     if hasattr(metsumm, 'STEPNO'):
         metsumm.STEPNO += stepno.lower()=="before forward"
     else:
@@ -11,7 +12,7 @@ def metsumm(stepno=''):
             if 'CompileTime' in line or 'aten::' in line:
                 key = line.split()[-1]
                 value = x[i+1].split()[-1]
-                print('step {}-{}, key {}, value {}'.format(
+                xm.master_print('step {}-{}, key {}, value {}'.format(
                     metsumm.STEPNO, stepno, key, value)
                 )
     except RuntimeError:

--- a/fairseq/models/wav2vec/wav2vec2.py
+++ b/fairseq/models/wav2vec/wav2vec2.py
@@ -774,7 +774,7 @@ class TransformerEncoder(nn.Module):
     def extract_features(self, x, padding_mask=None):
 
         if padding_mask is not None:
-            x[padding_mask] = 0
+            x = index_put(x, padding_mask, 0)
 
         x_conv = self.pos_conv(x.transpose(1, 2))
         x_conv = x_conv.transpose(1, 2)

--- a/fairseq/tasks/audio_pretraining.py
+++ b/fairseq/tasks/audio_pretraining.py
@@ -99,26 +99,26 @@ class AudioPretrainingConfig(FairseqDataclass):
             "help": "flag to compute mask indices in data preparation.",
         },
     )
+    if precompute_mask_indices:
+        # The following are needed to precompute mask and mask channel indices
+        #   before model's forward.
+        mask_length: int = II("model.mask_length")
+        mask_prob: float = II("model.mask_prob")
+        mask_selection: str = II("model.mask_selection")
+        mask_other: float = II("model.mask_other")
+        no_mask_overlap: bool = II("model.no_mask_overlap")
+        mask_min_space: int = II("model.mask_min_space")
+        mask_channel_length: int = II("model.mask_channel_length")
+        mask_channel_prob: float = II("model.mask_channel_prob")
+        mask_channel_selection: str = II("model.mask_channel_selection")
+        mask_channel_other: float = II("model.mask_channel_other")
+        no_mask_channel_overlap: bool = II("model.no_mask_channel_overlap")
+        mask_channel_min_space: int = II("model.mask_channel_min_space")
 
-    # The following are needed to precompute mask and mask channel indices
-    #   before model's forward.
-    mask_length: int = II("model.mask_length")
-    mask_prob: float = II("model.mask_prob")
-    mask_selection: str = II("model.mask_selection")
-    mask_other: float = II("model.mask_other")
-    no_mask_overlap: bool = II("model.no_mask_overlap")
-    mask_min_space: int = II("model.mask_min_space")
-    mask_channel_length: int = II("model.mask_channel_length")
-    mask_channel_prob: float = II("model.mask_channel_prob")
-    mask_channel_selection: str = II("model.mask_channel_selection")
-    mask_channel_other: float = II("model.mask_channel_other")
-    no_mask_channel_overlap: bool = II("model.no_mask_channel_overlap")
-    mask_channel_min_space: int = II("model.mask_channel_min_space")
+        conv_feature_layers: str = II("model.conv_feature_layers")
+        encoder_embed_dim: int = II("model.encoder_embed_dim")
 
-    conv_feature_layers: str = II("model.conv_feature_layers")
-    encoder_embed_dim: int = II("model.encoder_embed_dim")
-
-    tpu: bool = II("common.tpu")
+        tpu: bool = II("common.tpu")
 
 
 @register_task("audio_pretraining", dataclass=AudioPretrainingConfig)
@@ -157,23 +157,26 @@ class AudioPretrainingTask(FairseqTask):
         return cls(cfg, target_dictionary=target_dictionary)
 
     def _get_mask_precompute_kwargs(self, cfg):
-        args = [
-            'mask_length',
-            'mask_prob',
-            'mask_selection',
-            'mask_other',
-            'no_mask_overlap',
-            'mask_min_space',
-            'mask_channel_length',
-            'mask_channel_prob',
-            'mask_channel_selection',
-            'mask_channel_other',
-            'no_mask_channel_overlap',
-            'mask_channel_min_space',
-            'encoder_embed_dim',
-            'conv_feature_layers',
-        ]
-        return {arg: cfg[arg] for arg in args}
+        if self.cfg.precompute_mask_indices:
+            args = [
+                'mask_length',
+                'mask_prob',
+                'mask_selection',
+                'mask_other',
+                'no_mask_overlap',
+                'mask_min_space',
+                'mask_channel_length',
+                'mask_channel_prob',
+                'mask_channel_selection',
+                'mask_channel_other',
+                'no_mask_channel_overlap',
+                'mask_channel_min_space',
+                'encoder_embed_dim',
+                'conv_feature_layers',
+            ]
+            return {arg: cfg[arg] for arg in args}
+        else:
+            return {}
 
     def load_dataset(self, split: str, task_cfg: FairseqDataclass = None, **kwargs):
         data_path = self.cfg.data

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -123,6 +123,17 @@ def move_to_cpu(sample):
     return apply_to_sample(_move_to_cpu, sample)
 
 
+def move_to_tpu(sample):
+
+    import torch_xla.core.xla_model as xm
+    device = xm.xla_device()
+
+    def _move_to_tpu(tensor):
+        return tensor.to(device)
+
+    return apply_to_sample(_move_to_tpu, sample)
+
+
 def get_incremental_state(
     module: MultiheadAttention,
     incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]],

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -66,7 +66,7 @@ def main(cfg: DictConfig) -> None:
     task = tasks.setup_task(cfg.task)
     # Load valid dataset (we load training data below, based on the latest checkpoint)
     for valid_sub_split in cfg.dataset.valid_subset.split(","):
-        task.load_dataset(valid_sub_split, combine=False, epoch=1, tpu=cfg.common.tpu)
+        task.load_dataset(valid_sub_split, combine=False, epoch=1)
 
     assert cfg.criterion, "Please specify criterion to train a model"
 


### PR DESCRIPTION
* Share and pass down model related args to rawaudiodataset correctly.
* fp16 bug fix on non-xla devices (self._inftensor change)
* use index_put to avoid dynamicity in model's fwd.
* Get rid of some unnecessary warnings for tpus to clean up stderr.
* Send logging outputs to cpu b4 logging to reduce atens.
* Util function to move cpu tensors to tpu.
* Use the util function to handle dummy batches to avoid crash at the
end of epoch in distributed training.

With these changes, ran a w2v2 workload on small dataset, and it takes 150 secs to do 200 steps as before:
```
2020-12-16 01:35:18 | INFO | train_inner | epoch 005:    616 / 1046 loss=4.942, ntokens=7792, nsentences=32, prob_perplexity=348.304, code_perplexity=345.724, temp=15.621, loss_0=4.792, loss_1=0.133, loss_2=0.017, accuracy=0.22857, wps=53.1, ups=0.01, wpb=7792, bsz=32, num_updates=4800, lr=7.5e-05, gnorm=0.897, train_wall=45, gb_free=7.7, gb_total=16, wall=4661
2020-12-16 01:37:47 | INFO | train_inner | epoch 005:    816 / 1046 loss=5.243, ntokens=10480, nsentences=32, prob_perplexity=409.905, code_perplexity=408.027, temp=15.605, loss_0=5.092, loss_1=0.133, loss_2=0.018, accuracy=0.18139, wps=70.1, ups=0.01, wpb=10480, bsz=32, num_updates=5000, lr=7.8125e-05, gnorm=0.746, train_wall=47, gb_free=7.7, gb_total=16, wall=4810
2020-12-16 01:40:16 | INFO | train_inner | epoch 005:   1016 / 1046 loss=4.945, ntokens=8476, nsentences=32, prob_perplexity=406.209, code_perplexity=403.644, temp=15.589, loss_0=4.794, loss_1=0.133, loss_2=0.019, accuracy=0.21885, wps=57.1, ups=0.01, wpb=8476, bsz=32, num_updates=5200, lr=8.125e-05, gnorm=0.823, train_wall=46, gb_free=7.7, gb_total=16, wall=4959
```